### PR TITLE
Include hash in enumbatteries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructHelpers"
 uuid = "4093c41a-2008-41fd-82b8-e3f9d02b504f"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/StructHelpers.jl
+++ b/src/StructHelpers.jl
@@ -360,7 +360,7 @@ const ENUM_BATTERIES_DEFAULTS = (
     string_conversion = false,
     symbol_conversion = false,
     selfconstructor   = BATTERIES_DEFAULTS.selfconstructor,
-    hash              = BATTERIES_DEFAULTS.hash,
+    hash              = false,
     typesalt          = BATTERIES_DEFAULTS.typesalt,
 )
 
@@ -433,7 +433,7 @@ macro enumbatteries(T, kw...)
             """)
         end
     end
-    nt = merge(ENUM_BATTERIES_DEFAULTS, nt)
+    nt = merge(ENUM_BATTERIES_DEFAULTS, (; hash = haskey(nt, :typesalt)), nt)
     TT = Base.eval(__module__, T)::Type
     ret = quote end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,9 @@ end
 @enum Shape Circle = 7 Square = 8
 @enumbatteries Shape symbol_conversion = true typesalt = 0x0578044908fb9846
 
+@enum Size Small Medium Large
+@enumbatteries Size hash = true
+
 @testset "@enumbatteries" begin
     @test SH.has_batteries(Color)
     @test !SH.has_batteries(EnumNoBatteries)
@@ -169,9 +172,20 @@ end
     @test_throws Exception convert(String, Circle)
     @test_throws Exception Shape("Circle")
     @test_throws Exception convert(Shape, "Circle")
+end
 
+@testset "@enumbatteries hash" begin
+    # hash with typesalt
     @test hash(Circle) == hash(7, hash(0x0578044908fb9846))
     @test hash(Square) == hash(8, hash(0x0578044908fb9846))
+
+    # hash = true
+    @test hash(Small) == hash(0, hash(Size))
+    @test hash(Medium) == hash(1, hash(Size))
+    @test hash(Large) == hash(2, hash(Size))
+
+    # no hash by default
+    @test hash(Red) != hash(0, hash(Color))
 end
 
 struct Bad end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,7 @@ struct SNoIsEqual; a; end
     @test Empty1() !== Empty2()
     @test Empty1() != Empty2()
     @test hash(Empty1()) != hash(Empty2())
-    
+
     if VERSION >= v"1.8"
         @test_throws "Bad keyword argument value:" @macroexpand @batteries  SErrors kwconstructor="true"
         @test_throws "Unsupported keyword" @macroexpand @batteries SErrors kwconstructor=true nonsense=true
@@ -102,7 +102,7 @@ struct SNoIsEqual; a; end
         @test_throws Exception @macroexpand @batteries SErrors kwconstructor=true nonsense=true
         @test_throws Exception @macroexpand @batteries SErrors nonsense
     end
-    
+
 
     @testset "typesalt" begin
         @test hash(Salt1()) === hash(Salt1b())
@@ -131,8 +131,8 @@ end
 @enum Color Red Blue Green
 @enumbatteries Color string_conversion = true symbol_conversion = true selfconstructor = false
 
-@enum Shape Circle Square 
-@enumbatteries Shape symbol_conversion =true
+@enum Shape Circle = 7 Square = 8
+@enumbatteries Shape symbol_conversion = true typesalt = 0x0578044908fb9846
 
 @testset "@enumbatteries" begin
     @test SH.has_batteries(Color)
@@ -169,6 +169,9 @@ end
     @test_throws Exception convert(String, Circle)
     @test_throws Exception Shape("Circle")
     @test_throws Exception convert(Shape, "Circle")
+
+    @test hash(Circle) == hash(7, hash(0x0578044908fb9846))
+    @test hash(Square) == hash(8, hash(0x0578044908fb9846))
 end
 
 struct Bad end
@@ -177,7 +180,7 @@ struct Bad end
     @macroexpand @batteries Bad typesalt = 0xb6a4b9eeeb03b58b
     if VERSION >= v"1.7"
         @test_throws "`typesalt` must be literally `nothing` or an unsigned integer." @macroexpand @batteries Bad typesalt = "ouch"
-        @test_throws "Unsupported keyword." @macroexpand @batteries Bad does_not_exist = true   
+        @test_throws "Unsupported keyword." @macroexpand @batteries Bad does_not_exist = true
         @test_throws "Bad keyword argument value" @macroexpand @batteries Bad hash=:nonsense
         @test_throws "Bad keyword argument value" @macroexpand @batteries Bad StructTypes=:nonsense
     end
@@ -192,7 +195,7 @@ struct HashEqAs <: AbstractHashEqAs
     hash_eq_as
     payload
 end
-SH.@batteries HashEqAs 
+SH.@batteries HashEqAs
 struct HashEqAsTS1 <: AbstractHashEqAs
     hash_eq_as
     payload
@@ -250,7 +253,7 @@ Base.:(==)(::HashEqErr, ::HashEqErr) = error()
     @test SH.structural_hash(S(2,NaN), UInt(0)) != SH.structural_hash(S(2,NaN), UInt(1))
 end
 
-struct WithStructTypes 
+struct WithStructTypes
     x
     y
 end


### PR DESCRIPTION
This adds `hash` to `@enumbatteries`. For backward compatibility, `hash = false` by default. For convenience, setting `typesalt` will assume you want `hash = true`.