### PR TITLE
Bare flag sugar

### DIFF
--- a/src/StructHelpers.jl
+++ b/src/StructHelpers.jl
@@ -225,6 +225,7 @@ end
 @batteries S
 @batteries S hash=false # don't overload `Base.hash`
 @batteries S kwconstructor=true # add a keyword constructor
+@batteries S kwconstructor      # bare symbol is shorthand for `kwconstructor=true`
 ```
 
 Supported options and defaults are:
@@ -355,6 +356,12 @@ function error_parse_macro_kw(kw; comment=nothing)
     error(msg)
 end
 function parse_single_macro_kw(kw)
+    # Bare-symbol shorthand: `flag` is sugar for `flag=true`. Lets users write
+    # `@batteries T kwconstructor` instead of `@batteries T kwconstructor=true`.
+    # The resulting `flag => true` is then validated by the macro itself, so
+    # bare symbols that don't name a Bool option (e.g. `typesalt`) still
+    # produce the standard "Bad keyword argument value" error.
+    kw isa Symbol && return (kw => true)
     Meta.isexpr(kw, Symbol("=")) || error_parse_macro_kw(kw)
     length(kw.args) == 2 || error_parse_macro_kw(kw)
     key, val = kw.args
@@ -519,6 +526,7 @@ Automatically derive several methods for Enum type `T`.
 @enumbatteries Color
 @enumbatteries Color hash=false # don't overload `Base.hash`
 @enumbatteries Color symbol_conversion=true # allow convert(Color, :Blue), Color(:Blue), convert(Symbol, Blue), Symbol(Blue)
+@enumbatteries Color symbol_conversion      # bare symbol is shorthand for `symbol_conversion=true`
 ```
 
 Supported options and defaults are:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,10 @@ function SH.default_keywords(::Type{CountedDefaults})
     (a = 1, b = 2)
 end
 
+# Bare-flag sugar: `flag` ≡ `flag=true`, mixable with `flag=value`.
+struct SBare; a; b; end
+@batteries SBare kwconstructor kwshow hash=false
+
 @testset "@batteries" begin
     @test SBatteries(1,2) == SBatteries(1,2)
     @test SBatteries(1,[]) == SBatteries(1,[])
@@ -141,11 +145,20 @@ end
     if VERSION >= v"1.8"
         @test_throws "Bad keyword argument value:" @macroexpand @batteries  SErrors kwconstructor="true"
         @test_throws "Unsupported keyword" @macroexpand @batteries SErrors kwconstructor=true nonsense=true
-        @test_throws "Expected a keyword argument of the form name = value" @macroexpand @batteries SErrors nonsense
+        # Bare symbol is now sugar for `=true`, so an unknown bare flag fails
+        # as an unsupported keyword rather than as a parse error.
+        @test_throws "Unsupported keyword" @macroexpand @batteries SErrors nonsense
     else
         @test_throws Exception @macroexpand @batteries  SErrors kwconstructor="true"
         @test_throws Exception @macroexpand @batteries SErrors kwconstructor=true nonsense=true
         @test_throws Exception @macroexpand @batteries SErrors nonsense
+    end
+
+    @testset "bare-flag sugar" begin
+        # Bare flag works as a substitute for `=true` and is freely mixable
+        # with explicit `=` assignments.
+        @test SBare(a=1, b=2) == SBare(1, 2)            # kwconstructor enabled
+        @test sprint(show, SBare(1, 2)) == "SBare(a = 1, b = 2)"  # kwshow enabled
     end
 
 


### PR DESCRIPTION
Allow using `@batteries T kwshow` instead of `@batteries T kwshow=true`. This is nice on its own, but also used in a later PR.
This builds on #17, so its diff will be smaller after #17 is merged.