### PR TITLE
Fix two more hash test errors on Julia 1.13+

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,8 +260,18 @@ SH.@batteries HashEqAsTS2 typesalt = 2
 
     @test hash(HashEqAsTS1(x->2x::Int, 1)) === hash(HashEqAsTS1(identity, 2))
     @test hash(HashEqAsTS2(x->2x::Int, 1)) != hash(HashEqAsTS1(identity, 2))
-    @test hash(HashEqAsTS1(identity, 1)) === 0x486b072c90d60e64
-    @test hash(HashEqAsTS2(x->5x, 1)) === 0xa4360acf486c15a4
+    # The contract for `typesalt = N` is
+    #   hash(o, h) == hash(hash_eq_as(o), hash(N, h))
+    # which (by design) excludes the type identity itself. We check
+    # this contract directly; pinning literal hash values would be
+    # fragile because `hash(::Int, ::UInt)` is not stable across Julia
+    # versions. We pass an explicit seed `h` so the check does not
+    # depend on `hash(x)`'s no-arg default (which changed in Julia
+    # 1.11+ to use a randomized initial seed).
+    let h = UInt(0)
+        @test hash(HashEqAsTS1(identity, 1), h) === hash(1, hash(1, h))
+        @test hash(HashEqAsTS2(x->5x, 1), h)    === hash(5, hash(2, h))
+    end
 end
 
 mutable struct HashEqErr


### PR DESCRIPTION
PR #17 replaced most literal hash-value assertions in the typesalt and hash_eq_as testsets with contract-based checks of the form

    hash(o, h) === hash(hash_eq_as(o), hash(typesalt, h))

The two pinned hash literals at the end of the hash_eq_as testset were left untouched and fail on Julia 1.13+ for the same underlying reason: hash(::Int, ::UInt) is not stable across Julia versions.

Replace those two with the same contract pattern. Verified passing on Julia 1.6, 1.12, 1.13, and nightly (1.14-DEV).