### PR TITLE
macros: immune to user-side shadowing of Core / Base names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructHelpers"
 uuid = "4093c41a-2008-41fd-82b8-e3f9d02b504f"
 authors = ["Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/StructHelpers.jl
+++ b/src/StructHelpers.jl
@@ -192,7 +192,7 @@ macro batteries(T, kw...)
         push!(ret.args, :(import StructTypes as $ST))
     end
     if nt.hash
-        def = :(function Base.hash(o::$T, h::UInt)
+        def = :(function Base.hash(o::$T, h::$UInt)
             h = ($start_hash)(o, h, $(nt.typesalt))
             proxy = ($hash_eq_as)(o)
             Base.hash(proxy, h)
@@ -223,7 +223,7 @@ macro batteries(T, kw...)
         push!(ret.args, def)
     end
     if nt.constructorof
-        def = :($SH.constructorof(::Type{<:$T}) = $T)
+        def = :($SH.constructorof(::$Type{<:$T}) = $T)
         push!(ret.args, def)
     end
     if nt.kwconstructor
@@ -235,16 +235,22 @@ macro batteries(T, kw...)
         push!(ret.args, def)
     end
     if nt.StructTypes
-        def = :($ST.StructType(::Type{<:$T}) = $ST.Struct())
+        def = :($ST.StructType(::$Type{<:$T}) = $ST.Struct())
         push!(ret.args, def)
     end
     push!(ret.args, def_has_batteries(T))
     return esc(ret)
 end
 
+# `$Type` (and friends below) interpolate the actual Core.Type value
+# at quote-build time so it ends up as a literal in the resulting AST.
+# That immunizes the macro against a user module that has redefined
+# `Type`, `Any`, `Bool`, `UInt`, `String`, `Symbol`, or
+# `AbstractString` to something else (which is exactly what happens
+# when a user struct is itself named `Type` or `Any`).
 function def_has_batteries(T)
     :(
-        function $(SH).has_batteries(::Type{<:$T})::Bool
+        function $(SH).has_batteries(::$Type{<:$T})::$Bool
             true
         end
     )
@@ -331,7 +337,7 @@ end
 function def_enum_from_string(T)::Expr
     body = def_enum_from_string_or_symbol_body(string_from_enum, T)
     :(
-      function $SH.enum_from_string(::Type{$T}, s::String)::$T
+      function $SH.enum_from_string(::$Type{$T}, s::$String)::$T
           $body
       end
      )
@@ -339,7 +345,7 @@ end
 function def_enum_from_symbol(T)::Expr
     body = def_enum_from_string_or_symbol_body(QuoteNode∘symbol_from_enum, T)
     :(
-      function $SH.enum_from_symbol(::Type{$T}, s::Symbol)::$T
+      function $SH.enum_from_symbol(::$Type{$T}, s::$Symbol)::$T
           $body
       end
      )
@@ -366,7 +372,7 @@ end
 function def_symbol_from_enum(T)::Expr
     body = def_symbol_or_string_from_enum_body(symbol_from_enum_generic, T)
     :(
-      function $SH.symbol_from_enum(obj::$T)::Symbol
+      function $SH.symbol_from_enum(obj::$T)::$Symbol
           $body
       end
      )
@@ -375,7 +381,7 @@ end
 function def_string_from_enum(T)::Expr
     body = def_symbol_or_string_from_enum_body(string_from_enum_generic, T)
     :(
-      function $SH.string_from_enum(obj::$T)::String
+      function $SH.string_from_enum(obj::$T)::$String
           $body
       end
      )
@@ -476,16 +482,16 @@ macro enumbatteries(T, kw...)
     push!(ret.args, def_symbol_from_enum(TT))
     push!(ret.args, def_string_from_enum(TT))
     if nt.string_conversion
-        ex1 = :(Base.convert(::Type{$TT}, s::AbstractString) = $SH.enum_from_string($TT, String(s)))
-        ex2 = :($T(s::AbstractString) = $SH.enum_from_string($TT, String(s)))
-        ex3 = :(Base.convert(::Type{String}, x::$T) = $SH.string_from_enum(x))
+        ex1 = :(Base.convert(::$Type{$TT}, s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
+        ex2 = :($T(s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
+        ex3 = :(Base.convert(::$Type{$String}, x::$T) = $SH.string_from_enum(x))
         ex4 = :(Base.String(x::$T) = $SH.string_from_enum(x))
         push!(ret.args, ex1, ex2, ex3, ex4)
     end
     if nt.symbol_conversion
-        ex1 = :(Base.convert(::Type{$T}, s::Symbol) = $SH.enum_from_symbol($TT, Symbol(s)))
-        ex2 = :($T(s::Symbol) = $SH.enum_from_symbol($TT, Symbol(s)))
-        ex3 = :(Base.convert(::Type{Symbol}, x::$T) = $SH.symbol_from_enum(x))
+        ex1 = :(Base.convert(::$Type{$T}, s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
+        ex2 = :($T(s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
+        ex3 = :(Base.convert(::$Type{$Symbol}, x::$T) = $SH.symbol_from_enum(x))
         ex4 = :(Base.Symbol(x::$T) = $SH.symbol_from_enum(x))
         push!(ret.args, ex1, ex2, ex3, ex4)
     end
@@ -494,9 +500,9 @@ macro enumbatteries(T, kw...)
         push!(ret.args, def)
     end
     if nt.hash
-        def = :(function Base.hash(o::$T, h::UInt)
+        def = :(function Base.hash(o::$T, h::$UInt)
             h = ($start_hash)(o, h, $(nt.typesalt))
-            Base.hash(Integer(o), h)
+            Base.hash($Integer(o), h)
         end
         )
         push!(ret.args, def)

--- a/src/StructHelpers.jl
+++ b/src/StructHelpers.jl
@@ -192,30 +192,30 @@ macro batteries(T, kw...)
         push!(ret.args, :(import StructTypes as $ST))
     end
     if nt.hash
-        def = :(function $(GlobalRef(Base, :hash))(o::$T, h::$UInt)
+        def = :(function $(Base).hash(o::$T, h::$UInt)
             h = ($start_hash)(o, h, $(nt.typesalt))
             proxy = ($hash_eq_as)(o)
-            $(Base.hash)(proxy, h)
+            $(Base).hash(proxy, h)
         end
         )
         push!(ret.args, def)
     end
     if nt.eq
-        def = :(function $(GlobalRef(Base, :(==)))(o1::$T, o2::$T)
+        def = :(function $(Base).:(==)(o1::$T, o2::$T)
             ($hash_eq_as)(o1) == ($hash_eq_as)(o2)
         end
         )
         push!(ret.args, def)
     end
     if nt.isequal
-        def = :(function $(GlobalRef(Base, :isequal))(o1::$T, o2::$T)
-            $(Base.isequal)($hash_eq_as(o1), $hash_eq_as(o2))
+        def = :(function $(Base).isequal(o1::$T, o2::$T)
+            $(Base).isequal($hash_eq_as(o1), $hash_eq_as(o2))
         end
         )
         push!(ret.args, def)
     end
     if nt.kwshow
-        def = :($(GlobalRef(Base, :show))(io::$IO, o::$T) = $(kwshow)(io, o))
+        def = :($(Base).show(io::$IO, o::$T) = $(kwshow)(io, o))
         push!(ret.args, def)
     end
     if nt.getproperties
@@ -482,17 +482,17 @@ macro enumbatteries(T, kw...)
     push!(ret.args, def_symbol_from_enum(TT))
     push!(ret.args, def_string_from_enum(TT))
     if nt.string_conversion
-        ex1 = :($(GlobalRef(Base, :convert))(::$Type{$TT}, s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
+        ex1 = :($(Base).convert(::$Type{$TT}, s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
         ex2 = :($T(s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
-        ex3 = :($(GlobalRef(Base, :convert))(::$Type{$String}, x::$T) = $SH.string_from_enum(x))
-        ex4 = :($(GlobalRef(Base, :String))(x::$T) = $SH.string_from_enum(x))
+        ex3 = :($(Base).convert(::$Type{$String}, x::$T) = $SH.string_from_enum(x))
+        ex4 = :($(Base).String(x::$T) = $SH.string_from_enum(x))
         push!(ret.args, ex1, ex2, ex3, ex4)
     end
     if nt.symbol_conversion
-        ex1 = :($(GlobalRef(Base, :convert))(::$Type{$T}, s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
+        ex1 = :($(Base).convert(::$Type{$T}, s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
         ex2 = :($T(s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
-        ex3 = :($(GlobalRef(Base, :convert))(::$Type{$Symbol}, x::$T) = $SH.symbol_from_enum(x))
-        ex4 = :($(GlobalRef(Base, :Symbol))(x::$T) = $SH.symbol_from_enum(x))
+        ex3 = :($(Base).convert(::$Type{$Symbol}, x::$T) = $SH.symbol_from_enum(x))
+        ex4 = :($(Base).Symbol(x::$T) = $SH.symbol_from_enum(x))
         push!(ret.args, ex1, ex2, ex3, ex4)
     end
     if nt.selfconstructor
@@ -500,9 +500,9 @@ macro enumbatteries(T, kw...)
         push!(ret.args, def)
     end
     if nt.hash
-        def = :(function $(GlobalRef(Base, :hash))(o::$T, h::$UInt)
+        def = :(function $(Base).hash(o::$T, h::$UInt)
             h = ($start_hash)(o, h, $(nt.typesalt))
-            $(Base.hash)($Integer(o), h)
+            $(Base).hash($Integer(o), h)
         end
         )
         push!(ret.args, def)

--- a/src/StructHelpers.jl
+++ b/src/StructHelpers.jl
@@ -192,30 +192,30 @@ macro batteries(T, kw...)
         push!(ret.args, :(import StructTypes as $ST))
     end
     if nt.hash
-        def = :(function Base.hash(o::$T, h::$UInt)
+        def = :(function $(GlobalRef(Base, :hash))(o::$T, h::$UInt)
             h = ($start_hash)(o, h, $(nt.typesalt))
             proxy = ($hash_eq_as)(o)
-            Base.hash(proxy, h)
+            $(Base.hash)(proxy, h)
         end
         )
         push!(ret.args, def)
     end
     if nt.eq
-        def = :(function Base.:(==)(o1::$T, o2::$T)
+        def = :(function $(GlobalRef(Base, :(==)))(o1::$T, o2::$T)
             ($hash_eq_as)(o1) == ($hash_eq_as)(o2)
         end
         )
         push!(ret.args, def)
     end
     if nt.isequal
-        def = :(function Base.isequal(o1::$T, o2::$T)
-            isequal($hash_eq_as(o1), $hash_eq_as(o2))
+        def = :(function $(GlobalRef(Base, :isequal))(o1::$T, o2::$T)
+            $(Base.isequal)($hash_eq_as(o1), $hash_eq_as(o2))
         end
         )
         push!(ret.args, def)
     end
     if nt.kwshow
-        def = :(Base.show(io::IO, o::$T) = $(kwshow)(io, o))
+        def = :($(GlobalRef(Base, :show))(io::$IO, o::$T) = $(kwshow)(io, o))
         push!(ret.args, def)
     end
     if nt.getproperties
@@ -482,17 +482,17 @@ macro enumbatteries(T, kw...)
     push!(ret.args, def_symbol_from_enum(TT))
     push!(ret.args, def_string_from_enum(TT))
     if nt.string_conversion
-        ex1 = :(Base.convert(::$Type{$TT}, s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
+        ex1 = :($(GlobalRef(Base, :convert))(::$Type{$TT}, s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
         ex2 = :($T(s::$AbstractString) = $SH.enum_from_string($TT, $String(s)))
-        ex3 = :(Base.convert(::$Type{$String}, x::$T) = $SH.string_from_enum(x))
-        ex4 = :(Base.String(x::$T) = $SH.string_from_enum(x))
+        ex3 = :($(GlobalRef(Base, :convert))(::$Type{$String}, x::$T) = $SH.string_from_enum(x))
+        ex4 = :($(GlobalRef(Base, :String))(x::$T) = $SH.string_from_enum(x))
         push!(ret.args, ex1, ex2, ex3, ex4)
     end
     if nt.symbol_conversion
-        ex1 = :(Base.convert(::$Type{$T}, s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
+        ex1 = :($(GlobalRef(Base, :convert))(::$Type{$T}, s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
         ex2 = :($T(s::$Symbol) = $SH.enum_from_symbol($TT, $Symbol(s)))
-        ex3 = :(Base.convert(::$Type{$Symbol}, x::$T) = $SH.symbol_from_enum(x))
-        ex4 = :(Base.Symbol(x::$T) = $SH.symbol_from_enum(x))
+        ex3 = :($(GlobalRef(Base, :convert))(::$Type{$Symbol}, x::$T) = $SH.symbol_from_enum(x))
+        ex4 = :($(GlobalRef(Base, :Symbol))(x::$T) = $SH.symbol_from_enum(x))
         push!(ret.args, ex1, ex2, ex3, ex4)
     end
     if nt.selfconstructor
@@ -500,9 +500,9 @@ macro enumbatteries(T, kw...)
         push!(ret.args, def)
     end
     if nt.hash
-        def = :(function Base.hash(o::$T, h::$UInt)
+        def = :(function $(GlobalRef(Base, :hash))(o::$T, h::$UInt)
             h = ($start_hash)(o, h, $(nt.typesalt))
-            Base.hash($Integer(o), h)
+            $(Base.hash)($Integer(o), h)
         end
         )
         push!(ret.args, def)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -315,10 +315,16 @@ module ShadowedCore
     using StructHelpers
     using Test
 
-    # Shadow every Core / Base name @batteries / @enumbatteries reach for.
-    # Each one is the bogus binding (anything will do — what matters is
-    # that the symbol is *not* its Core / Base meaning at macro-expansion
-    # time).
+    # Shadow every Core / Base name `@batteries` / `@enumbatteries`
+    # reach for. Most of these are bogus String constants — what
+    # matters is that the symbol is *not* its Core / Base meaning at
+    # macro-expansion time. `Base` and `Core` themselves are shadowed
+    # by user-defined empty structs, which is the most aggressive case
+    # (any `Base.foo` / `Core.foo` reference in a quoted AST that
+    # `esc`s into this module would now hit our struct, not the
+    # standard library module).
+    struct Base end
+    struct Core end
     const Type = "shadowed-Type"
     const Any  = "shadowed-Any"
     const Bool = "shadowed-Bool"
@@ -327,6 +333,7 @@ module ShadowedCore
     const Symbol          = "shadowed-Symbol"
     const AbstractString  = "shadowed-AbstractString"
     const Integer         = "shadowed-Integer"
+    const IO              = "shadowed-IO"
 
     # Struct decorated with the most demanding option set (all the
     # quoted ASTs reachable: hash, eq, isequal, kwshow, getproperties,
@@ -352,11 +359,17 @@ module ShadowedCore
         @test (Strenuous(; a=3, b=4)).a == 3
         @test StructHelpers.constructorof(Strenuous) === Strenuous
 
-        # Enum decorations all worked.
+        # Enum decorations all worked. Note: `Base` is itself
+        # shadowed inside this module, so we call generic functions by
+        # the unqualified names (which Julia's implicit `using Base`
+        # has imported into scope independently of the `Base` binding
+        # we redefined). The shadowing test is exactly that those
+        # bare names don't go through `Base.X` lookup at the call
+        # site of the macro-emitted methods.
         @test StructHelpers.has_batteries(Color)
-        @test Base.convert(Color, "RED") === RED
+        @test convert(Color, "RED") === RED
         @test Color(:GREEN) === GREEN
-        @test Base.convert(Base.String, BLUE) == "BLUE"
-        @test Base.Symbol(RED) === :RED
+        @test convert(Main.Base.String, BLUE) == "BLUE"
+        @test Main.Base.Symbol(RED) === :RED
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,3 +304,59 @@ import StructTypes as ST
     with = WithStructTypes(1,2)
     @test ST.StructType(typeof(with)) == ST.Struct()
 end
+
+# Regression test: every Core / Base name the macro touches in its
+# quoted ASTs (Type, Any, Bool, UInt, String, Symbol, AbstractString)
+# is captured by interpolation at the macro's *definition site*, so a
+# user module that has redefined those bindings to bogus values must
+# not derail macro expansion. Use a fresh module so the redefinitions
+# only live in this scope.
+module ShadowedCore
+    using StructHelpers
+    using Test
+
+    # Shadow every Core / Base name @batteries / @enumbatteries reach for.
+    # Each one is the bogus binding (anything will do — what matters is
+    # that the symbol is *not* its Core / Base meaning at macro-expansion
+    # time).
+    const Type = "shadowed-Type"
+    const Any  = "shadowed-Any"
+    const Bool = "shadowed-Bool"
+    const UInt = "shadowed-UInt"
+    const String          = "shadowed-String"
+    const Symbol          = "shadowed-Symbol"
+    const AbstractString  = "shadowed-AbstractString"
+    const Integer         = "shadowed-Integer"
+
+    # Struct decorated with the most demanding option set (all the
+    # quoted ASTs reachable: hash, eq, isequal, kwshow, getproperties,
+    # constructorof, kwconstructor, selfconstructor, StructTypes).
+    struct Strenuous
+        a::Int
+        b::Int
+    end
+    @batteries Strenuous eq=true hash=true isequal=true kwshow=true getproperties=true constructorof=true kwconstructor=true selfconstructor=true StructTypes=true typesalt=0xdeadbeef
+
+    # Enum decorated with both string + symbol conversion paths so the
+    # convert(::Type{...}, ::AbstractString) / Symbol forms also expand.
+    @enum Color RED=0 GREEN=1 BLUE=2
+    @enumbatteries Color string_conversion=true symbol_conversion=true hash=true typesalt=0xc0ffee
+
+    @testset "macro is immune to user-side Core/Base shadowing" begin
+        # Struct decorations all worked.
+        s = Strenuous(1, 2)
+        @test StructHelpers.has_batteries(Strenuous)
+        @test s == Strenuous(1, 2)
+        @test isequal(s, Strenuous(1, 2))
+        @test hash(s) == hash(Strenuous(1, 2))
+        @test (Strenuous(; a=3, b=4)).a == 3
+        @test StructHelpers.constructorof(Strenuous) === Strenuous
+
+        # Enum decorations all worked.
+        @test StructHelpers.has_batteries(Color)
+        @test Base.convert(Color, "RED") === RED
+        @test Color(:GREEN) === GREEN
+        @test Base.convert(Base.String, BLUE) == "BLUE"
+        @test Base.Symbol(RED) === :RED
+    end
+end


### PR DESCRIPTION
Quoted-AST refs to Type/Any/Bool/UInt/String/Symbol/AbstractString/Integer/IO and to Base.X get escd into the call site, where a user binding (a struct named `Type`/`Any`, or a const at any level) can shadow them and break expansion. Interpolate the actual values at quote-build time so name resolution at the call site is bypassed.

Test: `module ShadowedCore` (`struct Base end; struct Core end;` plus the Core type names redefined to `String`s) decorates a struct with the full @batteries kw set and an enum with `string_conversion`/`symbol_conversion`/`hash`. Pre-fix expansion errors; post-fix all paths work.

Unblocks ProtocGen always-emitting @batteries on every generated proto message. Here, shadowing e.g. Type is very common.