### PR TITLE
Add Aqua.jl quality tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,20 @@ version = "1.6.0"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 
 [compat]
+Aqua = "0.8, 1"
 ConstructionBase = "1.3"
+StructTypes = "1"
+# `Test` is a stdlib. On Julia < 1.11 it is reported as unversioned
+# (matched by `<0.0.1`); on Julia >= 1.11 it has a real version (matched
+# by `1`). The union keeps Aqua's `test_deps_compat` check happy on all
+# supported Julia versions.
+Test = "<0.0.1, 1"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StructTypes"]
+test = ["Aqua", "Test", "StructTypes"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using StructHelpers: @batteries, @battery, StructHelpers, @enumbatteries, @enumbattery
 const SH = StructHelpers
 using Test
+using Aqua
 
 struct SVanilla
     a
@@ -714,4 +715,8 @@ module ShadowedCore
         @test convert(Main.Base.String, BLUE) == "BLUE"
         @test Main.Base.Symbol(RED) === :RED
     end
+end
+
+@testset "Aqua" begin
+    Aqua.test_all(StructHelpers)
 end


### PR DESCRIPTION
- Add Aqua to test extras with compat bound
- Add compat entries for StructTypes and Test (fixes Aqua's test_deps_compat extras check)
- Run Aqua.test_all in runtests.jl at the last test as it takes much longer than other tests so that errors are found quickly

This addresses a part of https://github.com/jw3126/StructHelpers.jl/pull/21#pullrequestreview-4295771127.