### PR TITLE
Add Jet

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,18 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - name: Drop JET deps on Julia versions JET does not support
+        # JET requires 1.7 <= Julia <= 1.12, so Pkg cannot resolve
+        # JET on Julia 1.6 or on nightly. Strip JET from Project.toml
+        # (compat + extras + targets) and from runtests.jl on those
+        # rows so the rest of the test suite still runs green.
+        # The job using a registered JET-supported Julia version ('1')
+        # keeps full JET coverage.
+        if: matrix.version == 'nightly' || matrix.version == '1.6'
+        run: |
+          sed -i '/^JET = /d' Project.toml
+          sed -i 's/, "JET"//' Project.toml
+          sed -i '/^@testset "JET" begin$/,/^end$/d' test/runtests.jl
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 [compat]
 Aqua = "0.8, 1"
 ConstructionBase = "1.3"
+JET = "0.9, 0.10, 0.11"
 StructTypes = "1"
 # `Test` is a stdlib. On Julia < 1.11 it is reported as unversioned
 # (matched by `<0.0.1`); on Julia >= 1.11 it has a real version (matched
@@ -19,8 +20,9 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "StructTypes"]
+test = ["Aqua", "JET", "Test", "StructTypes"]

--- a/src/StructHelpers.jl
+++ b/src/StructHelpers.jl
@@ -350,9 +350,7 @@ function def_batteries(__module__, T, kw, base)
     ret = quote end
 
     need_fieldnames = nt.kwconstructor || nt.getproperties
-    if need_fieldnames
-        fieldnames = Base.fieldnames(Base.eval(__module__, T))
-    end
+    fieldnames = need_fieldnames ? Base.fieldnames(Base.eval(__module__, T)) : ()
     need_StructTypes = nt.StructTypes
     if need_StructTypes
         push!(ret.args, :(import StructTypes as $ST))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -720,3 +720,9 @@ end
 @testset "Aqua" begin
     Aqua.test_all(StructHelpers)
 end
+
+@testset "JET" begin
+    using JET
+    result = JET.report_package(StructHelpers)
+    @test isempty(JET.get_reports(result))
+end


### PR DESCRIPTION
The actual changed needed to let JET pass, were a lot easier than I thought. It was only the fix I already had in the `showrepr` branch. But this is also due to the fact that JET does not cover too much via `report_package`, as most of the code is kind of "passive" as long as the macros are not executed, which we currently don't do.

However, actually adding JET to the test suite currently is a mess. For once because of Julia 1.6 support, which is not JET-friendly. But it's mostly about JET not supporting Julia 1.13 and special-casing (currently) 1.14.
So some back and forth with Claude indicated that the best solution actually might be to just hide JET completely from Julia 1.6 and nightly when run in CI by letting `sed` remove all traces of it before starting the actual testing. Not pretty, but seems to be better than the alternatives. Let's see whether this actually works.

This contains the changes in #25. So if you want to go step-by-step, it's #25 and then rebasing #26 on top of #25. If you want to do all at once, you can directly use #26 and close #25. I'd recommend to do it step-by-step, but it's your call.